### PR TITLE
Basic prototype

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,10 +5,10 @@ Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Imperial College of Science, Technology and Medicine",
                     role = "cph"))
-Description: Access databases from 'orderly2' while running packets.
+Description: Access databases from 'orderly2' while running reports.
     Includes the basic 'SQL' support originally included in 'orderly'
     for establishing connections and setting up data for use within a
-    packet.
+    report.
 License: MIT + file LICENSE
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
@@ -17,8 +17,9 @@ URL: https://github.com/vimc/orderly2.db
 BugReports: https://github.com/vimc/orderly2.db/issues
 Imports:
     DBI,
-    RSQLite,
+    fs,
     orderly2 (>= 0.1.2)
 Suggests:
+    RSQLite,
     testthat (>= 3.0.0)
 Config/testthat/edition: 3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,5 +21,6 @@ Imports:
     orderly2 (>= 0.1.2)
 Suggests:
     RSQLite,
+    mockery,
     testthat (>= 3.0.0)
 Config/testthat/edition: 3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,6 +15,10 @@ Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.1
 URL: https://github.com/vimc/orderly2.db
 BugReports: https://github.com/vimc/orderly2.db/issues
+Imports:
+    DBI,
+    RSQLite,
+    orderly2
 Suggests:
     testthat (>= 3.0.0)
 Config/testthat/edition: 3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,3 +24,4 @@ Suggests:
     mockery,
     testthat (>= 3.0.0)
 Config/testthat/edition: 3
+Remotes: vimc/orderly2

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,7 @@ BugReports: https://github.com/vimc/orderly2.db/issues
 Imports:
     DBI,
     RSQLite,
-    orderly2
+    orderly2 (>= 0.1.2)
 Suggests:
     testthat (>= 3.0.0)
 Config/testthat/edition: 3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,10 +18,12 @@ BugReports: https://github.com/vimc/orderly2.db/issues
 Imports:
     DBI,
     fs,
+    jsonlite,
     orderly2 (>= 0.1.2)
 Suggests:
     RSQLite,
     mockery,
-    testthat (>= 3.0.0)
+    testthat (>= 3.0.0),
+    withr
 Config/testthat/edition: 3
 Remotes: vimc/orderly2

--- a/R/config.R
+++ b/R/config.R
@@ -1,0 +1,1 @@
+## We'll need to register our config reading support here

--- a/R/config.R
+++ b/R/config.R
@@ -1,1 +1,0 @@
-## We'll need to register our config reading support here

--- a/R/import.R
+++ b/R/import.R
@@ -1,0 +1,24 @@
+## Functions copied over from orderly:
+
+check_symbol_from_str <- function(str, name) {
+  assert_scalar_character(str)
+  dat <- strsplit(str, "::", fixed = TRUE)[[1L]]
+  if (length(dat) != 2) {
+    stop(sprintf("Expected fully qualified name for %s", name))
+  }
+  dat
+}
+
+
+## TODO: - in orderly we should check for paths starting with ~, or
+## just use fs here
+is_absolute_path <- function(path) {
+  grepl("^(~|/|[A-Z]:)", path, ignore.case = TRUE)
+}
+
+
+check_fields <- orderly2:::check_fields
+assert_named <- orderly2:::assert_named
+assert_scalar_character <- orderly2:::assert_scalar_character
+assert_character <- orderly2:::assert_character
+match_value <- orderly2:::match_value

--- a/R/import.R
+++ b/R/import.R
@@ -1,7 +1,7 @@
 ## Functions copied over from orderly:
 
 check_symbol_from_str <- function(str, name) {
-  assert_scalar_character(str)
+  assert_scalar_character(str, name)
   dat <- strsplit(str, "::", fixed = TRUE)[[1L]]
   if (length(dat) != 2) {
     stop(sprintf("Expected fully qualified name for %s", name))

--- a/R/import.R
+++ b/R/import.R
@@ -10,13 +10,6 @@ check_symbol_from_str <- function(str, name) {
 }
 
 
-## TODO: - in orderly we should check for paths starting with ~, or
-## just use fs here
-is_absolute_path <- function(path) {
-  grepl("^(~|/|[A-Z]:)", path, ignore.case = TRUE)
-}
-
-
 check_fields <- orderly2:::check_fields
 assert_named <- orderly2:::assert_named
 assert_scalar_character <- orderly2:::assert_scalar_character

--- a/R/plugin.R
+++ b/R/plugin.R
@@ -15,14 +15,12 @@ orderly_db_config <- function(data, filename) {
   assert_named(data, unique = TRUE, name = sprintf("%s:orderly2.db", filename))
   for (nm in names(data)) {
     db <- data[[nm]]
-    prefix <- sprintf("%s:orderly2.db:%s:", filename, nm)
+    prefix <- sprintf("%s:orderly2.db:%s", filename, nm)
     check_fields(db, prefix, c("driver", "args"), NULL)
     driver <- check_symbol_from_str(db$driver, paste0(prefix, ":driver"))
     data[[nm]]$driver <- driver
 
-    if (!is.null(db$args)) {
-      assert_named(db$args, TRUE, paste0(prefix, ":args"))
-    }
+    assert_named(db$args, TRUE, paste0(prefix, ":args"))
     ## TODO: instances here, once we support them, both instances and
     ## default_instance field
 

--- a/R/plugin.R
+++ b/R/plugin.R
@@ -1,20 +1,16 @@
-## TODO: these phases probably get renamed
-##
-## TODO: there are two phases for run - one copies files around before
-## running, the other is within the run phase?
 orderly_db_plugin <- function() {
   schema <- system.file("orderly.db.json", package = "orderly2.db",
                         mustWork = TRUE)
-  orderly2:::orderly_plugin(orderly_db_check,
-                            orderly_db_read,
-                            orderly_db_prepare,
-                            schema)
+  orderly2::orderly_plugin(orderly_db_config,
+                           orderly_db_read,
+                           orderly_db_run,
+                           schema)
 }
 
 
-## Reads orderly_config.yml, checks plugin configuration. Evaluated
+## Reads orderly_config.yml, configs plugin configuration. Evaluated
 ## from the root directory.
-orderly_db_check <- function(data, filename) {
+orderly_db_config <- function(data, filename) {
   fieldname <- function(x) sprintf("%s:orderly2.db:%s", filename, x)
   assert_named(data, unique = TRUE, name = sprintf("%s:orderly2.db", filename))
   for (nm in names(data)) {
@@ -94,7 +90,7 @@ orderly_db_read <- function(data, filename, root) {
 }
 
 
-orderly_db_prepare <- function(config, data, environment, path) {
+orderly_db_run <- function(config, data, parameters, environment, path) {
   res <- list(data = list())
 
   connections <- list()

--- a/R/plugin.R
+++ b/R/plugin.R
@@ -90,7 +90,8 @@ orderly_db_read <- function(data, filename, root) {
 }
 
 
-orderly_db_run <- function(config, data, parameters, environment, path) {
+orderly_db_run <- function(data, root, parameters, environment, path) {
+  config <- root$config$orderly2.db
   res <- list(data = list())
 
   connections <- list()
@@ -100,10 +101,8 @@ orderly_db_run <- function(config, data, parameters, environment, path) {
   for (nm in names(data$data)) {
     database <- data$data[[nm]]$database
     if (is.null(connections[[database]])) {
-      message(sprintf("Connecting to database '%s'", database))
       connections[[database]] <- orderly_db_connect(database, config)
     }
-    message(sprintf("Fetching data '%s'", nm))
     res$data[[nm]] <- DBI::dbGetQuery(
       connections[[database]], data$data[[nm]]$query)
     environment[[nm]] <- res$data[[nm]]
@@ -115,17 +114,17 @@ orderly_db_run <- function(config, data, parameters, environment, path) {
     DBI::dbDisconnect(con)
   }
 
-  ## We then need to serialise something about the downloaded data,
-  ## but for now we just return a list. Saving a hash would be ideal
-  ## really, along side columns (+ types?) and number of rows.
-
-  ## We might also save the final queries too, along with the instance
-  ## information (i.e., all the information that might end up not end
-  ## up in the final accounting?
   orderly_db_build_metadata(res)
 }
 
 
+## We then need to serialise something about the downloaded data,
+## but for now we just return a list. Saving a hash would be ideal
+## really, along side columns (+ types?) and number of rows.
+
+## We might also save the final queries too, along with the instance
+## information (i.e., all the information that might end up not end
+## up in the final accounting?
 orderly_db_build_metadata <- function(data) {
   dat <- list(
     data = lapply(data$data, function(d) {

--- a/R/plugin.R
+++ b/R/plugin.R
@@ -11,7 +11,6 @@ orderly_db_plugin <- function() {
 ## Reads orderly_config.yml, configs plugin configuration. Evaluated
 ## from the root directory.
 orderly_db_config <- function(data, filename) {
-  fieldname <- function(x) sprintf("%s:orderly2.db:%s", filename, x)
   assert_named(data, unique = TRUE, name = sprintf("%s:orderly2.db", filename))
   for (nm in names(data)) {
     db <- data[[nm]]

--- a/R/plugin.R
+++ b/R/plugin.R
@@ -1,0 +1,148 @@
+## TODO: these phases probably get renamed
+##
+## TODO: there are two phases for run - one copies files around before
+## running, the other is within the run phase?
+orderly_db_plugin <- function() {
+  schema <- system.file("orderly.db.json", package = "orderly2.db",
+                        mustWork = TRUE)
+  orderly2:::orderly_plugin(orderly_db_check,
+                            orderly_db_read,
+                            orderly_db_prepare,
+                            schema)
+}
+
+
+## Reads orderly_config.yml, checks plugin configuration. Evaluated
+## from the root directory.
+orderly_db_check <- function(data, filename) {
+  fieldname <- function(x) sprintf("%s:orderly2.db:%s", filename, x)
+  assert_named(data, unique = TRUE, name = sprintf("%s:orderly2.db", filename))
+  for (nm in names(data)) {
+    db <- data[[nm]]
+    prefix <- sprintf("%s:orderly2.db:%s:", filename, nm)
+    check_fields(db, prefix, c("driver", "args"), NULL)
+    driver <- check_symbol_from_str(db$driver, paste0(prefix, ":driver"))
+    data[[nm]]$driver <- driver
+
+    if (!is.null(db$args)) {
+      assert_named(db$args, TRUE, paste0(prefix, ":args"))
+    }
+    ## TODO: instances here, once we support them, both instances and
+    ## default_instance field
+
+    ## There are two things to check with SQLite - first that we don't
+    ## use in-memory databases as we'll never reconnect to them. This
+    ## is probably not that useful a check but orderly does do it so
+    ## we may have added it for some reason.
+    ##
+    ## The other is more important though, which is is that database
+    ## files *should* be presented as relative paths, but these paths
+    ## will be interpreted relative to the root. At the point where we
+    ## process this configuration we are guaranteed to have the
+    ## working directory be the orderly root so we can build an
+    ## absolute path at this point.
+    ##
+    ## Similar checks would be required for other database backends
+    ## that use absolute paths, there might be some way to make this
+    ## more general.
+    if (identical(driver, c("RSQLite", "SQLite"))) {
+      assert_scalar_character(db$args$dbname, paste0(prefix, ":args:dbname"))
+      if (db$args$dbname == ":memory:") {
+        stop("Can't use an in-memory database with orderly2.db")
+      }
+      if (!fs::is_absolute_path(db$args$dbname)) {
+        data[[nm]]$args$dbname <- file.path(getwd(), db$args$dbname)
+      }
+    }
+  }
+  data
+}
+
+
+## Reads orderly.yml, checks plugin use. Evaluated from the
+## packet/report source directory
+orderly_db_read <- function(data, filename, root) {
+  ## TODO: I am not sure why this gets the entire root object, but
+  ## nothing else does.
+  prefix <- sprintf("%s:orderly2.db", filename)
+  assert_named(data, name = prefix)
+  check_fields(data, prefix, "data", NULL)
+
+  assert_named(data$data, unique = TRUE, paste0(prefix, ":data"))
+  for (nm in names(data$data)) {
+    check_fields(data$data[[nm]], sprintf("%s:data:%s", prefix, nm),
+                 c("query", "database"), NULL)
+    match_value(data$data[[nm]]$database, names(root$config$orderly2.db),
+                sprintf("%s:data:%s:database", prefix, nm))
+
+    query <- data$data[[nm]]$query
+    assert_character(query, sprintf("%s:data:%s:query", prefix, nm))
+    if (length(query) == 1 && file.exists(query)) {
+      query <- readLines(query)
+    }
+    if (length(query) > 1) {
+      query <- paste(query, collapse = "\n")
+    }
+    data$data[[nm]]$query <- query
+  }
+
+  ## This return value also needs work - a plugin might reasonably
+  ## create files here (ours effectively does by reading in queries)
+  ## so we might want to indicate to orderly what we've done. So we
+  ## probably need some helper type?
+  data
+}
+
+
+orderly_db_prepare <- function(config, data, environment, path) {
+  res <- list(data = list())
+
+  connections <- list()
+
+  ## TODO: process views
+
+  for (nm in names(data$data)) {
+    database <- data$data[[nm]]$database
+    if (is.null(connections[[database]])) {
+      message(sprintf("Connecting to database '%s'", database))
+      connections[[database]] <- orderly_db_connect(database, config)
+    }
+    message(sprintf("Fetching data '%s'", nm))
+    res$data[[nm]] <- DBI::dbGetQuery(
+      connections[[database]], data$data[[nm]]$query)
+    environment[[nm]] <- res$data[[nm]]
+  }
+
+  ## TODO: copy out connections to the environment (don't close them)
+
+  for (con in connections) {
+    DBI::dbDisconnect(con)
+  }
+
+  ## We then need to serialise something about the downloaded data,
+  ## but for now we just return a list. Saving a hash would be ideal
+  ## really, along side columns (+ types?) and number of rows.
+
+  ## We might also save the final queries too, along with the instance
+  ## information (i.e., all the information that might end up not end
+  ## up in the final accounting?
+  orderly_db_build_metadata(res)
+}
+
+
+orderly_db_build_metadata <- function(data) {
+  dat <- list(
+    data = lapply(data$data, function(d) {
+      list(rows = jsonlite::unbox(nrow(d)),
+           cols = names(d))
+    }))
+  jsonlite::toJSON(dat, auto_unbox = FALSE, pretty = FALSE, na = "null",
+                   null = "null")
+}
+
+
+orderly_db_connect <- function(name, config) {
+  x <- config[[name]]
+  driver <- getExportedValue(x$driver[[1L]], x$driver[[2L]])
+  do.call(DBI::dbConnect, c(list(driver()), x$args))
+}

--- a/R/plugin.R
+++ b/R/plugin.R
@@ -56,8 +56,6 @@ orderly_db_config <- function(data, filename) {
 ## Reads orderly.yml, checks plugin use. Evaluated from the
 ## packet/report source directory
 orderly_db_read <- function(data, filename, root) {
-  ## TODO: I am not sure why this gets the entire root object, but
-  ## nothing else does.
   prefix <- sprintf("%s:orderly2.db", filename)
   assert_named(data, name = prefix)
   check_fields(data, prefix, "data", NULL)
@@ -80,10 +78,6 @@ orderly_db_read <- function(data, filename, root) {
     data$data[[nm]]$query <- query
   }
 
-  ## This return value also needs work - a plugin might reasonably
-  ## create files here (ours effectively does by reading in queries)
-  ## so we might want to indicate to orderly what we've done. So we
-  ## probably need some helper type?
   data
 }
 
@@ -93,8 +87,6 @@ orderly_db_run <- function(data, root, parameters, environment, path) {
   res <- list(data = list())
 
   connections <- list()
-
-  ## TODO: process views
 
   for (nm in names(data$data)) {
     database <- data$data[[nm]]$database

--- a/R/plugin.R
+++ b/R/plugin.R
@@ -98,8 +98,6 @@ orderly_db_run <- function(data, root, parameters, environment, path) {
     environment[[nm]] <- res$data[[nm]]
   }
 
-  ## TODO: copy out connections to the environment (don't close them)
-
   for (con in connections) {
     DBI::dbDisconnect(con)
   }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,0 +1,10 @@
+.onLoad <- function(...) {
+  ## TODO: we _really_ need the package name to be discoverable here
+  ## or we get weird errors if the user gets it wrong. It's gettable
+  ## here as:
+  ##
+  ## > packageName(environment(orderly_db_plugin))
+  ##
+  ## which is ok, and we could do this within the registration
+  orderly2:::orderly_register_plugin("orderly2.db", orderly_db_plugin())
+}

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,3 +1,3 @@
 .onLoad <- function(...) {
-  orderly2::orderly_plugin_register(orderly_db_plugin(), "orderly2.db")
+  orderly2::orderly_plugin_register(orderly_db_plugin(), "orderly2.db") # nocov
 }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,10 +1,3 @@
 .onLoad <- function(...) {
-  ## TODO: we _really_ need the package name to be discoverable here
-  ## or we get weird errors if the user gets it wrong. It's gettable
-  ## here as:
-  ##
-  ## > packageName(environment(orderly_db_plugin))
-  ##
-  ## which is ok, and we could do this within the registration
-  orderly2:::orderly_register_plugin("orderly2.db", orderly_db_plugin())
+  orderly2::orderly_plugin_register(orderly_db_plugin(), "orderly2.db")
 }

--- a/inst/orderly.db.json
+++ b/inst/orderly.db.json
@@ -1,0 +1,26 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "orderly/outpack custom schema",
+    "version": "0.0.1",
+
+    "type": "object",
+    "properties": {
+        "data": {
+            "additionalProperties": {
+                "type": "object",
+                "properties": {
+                    "rows": {
+                        "type": "number"
+                    },
+                    "cols": {
+                        "type": "array",
+                        "items": {
+                            "type": "character"
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "required": ["data"]
+}

--- a/tests/testthat/examples/minimal/orderly.yml
+++ b/tests/testthat/examples/minimal/orderly.yml
@@ -1,0 +1,12 @@
+orderly2.db:
+  data:
+    dat1:
+      query: SELECT * FROM mtcars
+      database: source
+
+script: script.R
+
+artefacts:
+  staticgraph:
+    description: A graph of things
+    filenames: mygraph.png

--- a/tests/testthat/examples/minimal/script.R
+++ b/tests/testthat/examples/minimal/script.R
@@ -1,0 +1,3 @@
+png("mygraph.png")
+plot(dat1)
+dev.off()

--- a/tests/testthat/helper-orderly-db.R
+++ b/tests/testthat/helper-orderly-db.R
@@ -1,0 +1,30 @@
+test_prepare_example <- function(examples, data) {
+  tmp <- tempfile()
+  withr::defer_parent(unlink(tmp, recursive = TRUE))
+  orderly2:::orderly_init(tmp)
+
+  writeLines(c(
+    "plugins:",
+    "  orderly2.db: ~",
+    "",
+    "orderly2.db:",
+    "  source:",
+    "    driver: RSQLite::SQLite",
+    "    args:",
+    "      dbname: source.sqlite"),
+    file.path(tmp, "orderly_config.yml"))
+
+  con <- DBI::dbConnect(RSQLite::SQLite(),
+                        dbname = file.path(tmp, "source.sqlite"))
+  for (nm in names(data)) {
+    DBI::dbWriteTable(con, nm, data[[nm]])
+  }
+  DBI::dbDisconnect(con)
+
+  fs::dir_create(file.path(tmp, "src"))
+  for (i in examples) {
+    fs::dir_copy(file.path("examples", i), file.path(tmp, "src"))
+  }
+
+  tmp
+}

--- a/tests/testthat/test-plugin.R
+++ b/tests/testthat/test-plugin.R
@@ -15,3 +15,62 @@ test_that("basic plugin use works", {
   expect_equal(meta_db$data$dat1$rows, nrow(mtcars))
   expect_equal(meta_db$data$dat1$cols, as.list(names(mtcars)))
 })
+
+
+test_that("validate plugin configuration", {
+  expect_error(
+    orderly_db_config(list(), "orderly_config.yml"),
+    "'orderly_config.yml:orderly2.db' must be named")
+  expect_error(
+    orderly_db_config(list(db = list()), "orderly_config.yml"),
+    "Fields missing from orderly_config.yml:orderly2.db:db: driver, args")
+  expect_error(
+    orderly_db_config(list(db = list(driver = NULL, args = NULL)),
+                      "orderly_config.yml"),
+    "'orderly_config.yml:orderly2.db:db:driver' must be a scalar")
+  expect_error(
+    orderly_db_config(list(db = list(driver = "db", args = NULL)),
+                      "orderly_config.yml"),
+    paste("Expected fully qualified name for",
+          "orderly_config.yml:orderly2.db:db:driver"))
+  expect_error(
+    orderly_db_config(list(db = list(driver = "pkg::db", args = NULL)),
+                      "orderly_config.yml"),
+    "'orderly_config.yml:orderly2.db:db:args' must be named")
+
+  ## Success:
+  expect_equal(
+    orderly_db_config(
+      list(db = list(driver = "pkg::db", args = list(a = 1))),
+      "orderly_config.yml"),
+    list(db = list(driver = c("pkg", "db"), args = list(a = 1))))
+})
+
+
+test_that("validate db for sqlite", {
+  expect_error(
+    orderly_db_config(
+      list(db = list(driver = "RSQLite::SQLite",
+                     args = list(dbname = ":memory:"))),
+      "orderly_config.yml"),
+    "Can't use an in-memory database with orderly2.db")
+
+  db <- tempfile(tmpdir = normalizePath(tempdir(), mustWork = TRUE))
+  expected <- list(db = list(driver = c("RSQLite", "SQLite"),
+                             args = list(dbname = db)))
+
+  expect_equal(
+    orderly_db_config(
+      list(db = list(driver = "RSQLite::SQLite",
+                     args = list(dbname = db))),
+      "orderly_config.yml"),
+    expected)
+  withr::with_dir(
+    dirname(db),
+    expect_equal(
+      orderly_db_config(
+        list(db = list(driver = "RSQLite::SQLite",
+                       args = list(dbname = basename(db)))),
+        "orderly_config.yml"),
+      expected))
+})

--- a/tests/testthat/test-plugin.R
+++ b/tests/testthat/test-plugin.R
@@ -1,0 +1,17 @@
+test_that("basic plugin use works", {
+  root <- test_prepare_example("minimal", list(mtcars = mtcars))
+  env <- new.env()
+  id <- orderly2::orderly_run("minimal", root = root, envir = env)
+  expect_type(id, "character")
+
+  expect_true(file.exists(
+    file.path(root, "archive", "minimal", id, "mygraph.png")))
+
+  meta <- outpack::outpack_root_open(root)$metadata(id, TRUE)
+  meta_db <- meta$custom$orderly$plugins$orderly2.db
+  expect_setequal(names(meta_db), "data")
+  expect_setequal(names(meta_db$data), "dat1")
+  expect_setequal(names(meta_db$data$dat1), c("rows", "cols"))
+  expect_equal(meta_db$data$dat1$rows, nrow(mtcars))
+  expect_equal(meta_db$data$dat1$cols, as.list(names(mtcars)))
+})

--- a/tests/testthat/test-plugin.R
+++ b/tests/testthat/test-plugin.R
@@ -55,7 +55,8 @@ test_that("validate db for sqlite", {
       "orderly_config.yml"),
     "Can't use an in-memory database with orderly2.db")
 
-  db <- tempfile(tmpdir = normalizePath(tempdir(), mustWork = TRUE))
+  db <- tempfile(
+    tmpdir = normalizePath(tempdir(), mustWork = TRUE, winslash = "/"))
   expected <- list(db = list(driver = c("RSQLite", "SQLite"),
                              args = list(dbname = db)))
 

--- a/tests/testthat/test-plugin.R
+++ b/tests/testthat/test-plugin.R
@@ -55,8 +55,10 @@ test_that("validate db for sqlite", {
       "orderly_config.yml"),
     "Can't use an in-memory database with orderly2.db")
 
-  db <- tempfile(
-    tmpdir = normalizePath(tempdir(), mustWork = TRUE, winslash = "/"))
+  db <- tempfile(tmpdir = normalizePath(tempdir(), mustWork = TRUE))
+  ## Tweak so that things behave sensibly on windows:
+  db <- gsub("\\", "/", db, fixed = TRUE)
+
   expected <- list(db = list(driver = c("RSQLite", "SQLite"),
                              args = list(dbname = db)))
 

--- a/tests/testthat/test-plugin.R
+++ b/tests/testthat/test-plugin.R
@@ -74,3 +74,9 @@ test_that("validate db for sqlite", {
         "orderly_config.yml"),
       expected))
 })
+
+
+test_that("can construct plugin", {
+  expect_identical(orderly_db_plugin(),
+                   orderly2:::.plugins$orderly2.db)
+})

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -4,3 +4,11 @@ test_that("null-or-value works", {
   expect_equal(NULL %||% NULL, NULL)
   expect_equal(NULL %||% 2, 2)
 })
+
+
+test_that("validate symbol", {
+  expect_equal(check_symbol_from_str("a::b", "thing"),
+               c("a", "b"))
+  expect_error(check_symbol_from_str("a:b", "thing"),
+               "Expected fully qualified name for thing")
+})


### PR DESCRIPTION
This PR implements a basic prototype of a plugin to handle VIMC-style database extraction. It's very similar to the approach used in the orderly2 plugin vignette

Not yet handled:

* creating temporary views
* saving the connection into the environment for arbitrary db manipulation
* coping with different database instances
* coping with secrets and environment variables in the configuration (this is something we probably want to consider more generally)