### PR TITLE
vimc-6825: allow connections to be exported to the report

### DIFF
--- a/R/import.R
+++ b/R/import.R
@@ -15,3 +15,4 @@ assert_named <- orderly2:::assert_named
 assert_scalar_character <- orderly2:::assert_scalar_character
 assert_character <- orderly2:::assert_character
 match_value <- orderly2:::match_value
+squote <- orderly2:::squote

--- a/R/plugin.R
+++ b/R/plugin.R
@@ -56,8 +56,14 @@ orderly_db_config <- function(data, filename) {
 ## packet/report source directory
 orderly_db_read <- function(data, filename, root) {
   prefix <- sprintf("%s:orderly2.db", filename)
+  optional <- c("data", "connection")
+  if (length(data) == 0) {
+    stop(sprintf("At least one of %s must be given in '%s'",
+                 paste(squote(optional), collapse = " or "),
+                 prefix))
+  }
   assert_named(data, name = prefix)
-  check_fields(data, prefix, NULL, c("data", "connection"))
+  check_fields(data, prefix, NULL, optional)
 
   if (length(data$data) > 0 ){
     assert_named(data$data, unique = TRUE, paste0(prefix, ":data"))

--- a/R/plugin.R
+++ b/R/plugin.R
@@ -85,6 +85,8 @@ orderly_db_read <- function(data, filename, root) {
   for (nm in names(data$connection)) {
     assert_character(data$connection[[nm]],
                      sprintf("%s:connection:%s", prefix, nm))
+    match_value(data$connection[[nm]], names(root$config$orderly2.db),
+                sprintf("%s:connection:%s", prefix, nm))
   }
 
   data

--- a/R/plugin.R
+++ b/R/plugin.R
@@ -57,9 +57,11 @@ orderly_db_config <- function(data, filename) {
 orderly_db_read <- function(data, filename, root) {
   prefix <- sprintf("%s:orderly2.db", filename)
   assert_named(data, name = prefix)
-  check_fields(data, prefix, "data", NULL)
+  check_fields(data, prefix, NULL, c("data", "connection"))
 
-  assert_named(data$data, unique = TRUE, paste0(prefix, ":data"))
+  if (length(data$data) > 0 ){
+    assert_named(data$data, unique = TRUE, paste0(prefix, ":data"))
+  }
   for (nm in names(data$data)) {
     check_fields(data$data[[nm]], sprintf("%s:data:%s", prefix, nm),
                  c("query", "database"), NULL)
@@ -75,6 +77,14 @@ orderly_db_read <- function(data, filename, root) {
       query <- paste(query, collapse = "\n")
     }
     data$data[[nm]]$query <- query
+  }
+
+  if (length(data$connection) > 0 ){
+    assert_named(data$connection, unique = TRUE, paste0(prefix, ":connection"))
+  }
+  for (nm in names(data$connection)) {
+    assert_character(data$connection[[nm]],
+                     sprintf("%s:connection:%s", prefix, nm))
   }
 
   data
@@ -97,8 +107,27 @@ orderly_db_run <- function(data, root, parameters, environment, path) {
     environment[[nm]] <- res$data[[nm]]
   }
 
-  for (con in connections) {
-    DBI::dbDisconnect(con)
+  export <- unlist(data$connection, FALSE, FALSE)
+
+  ## If a connection is used to a database that we we don't extract
+  ## data from, it won't be present yet, so add that here:
+  for (database in setdiff(export, names(connections))) {
+    connections[[database]] <- orderly_db_connect(database, config)
+  }
+
+  ## Close all the connections that are not needed in the report
+  ## itself
+  orderly_db_disconnect(connections[setdiff(names(connections), export)])
+
+  ## If any are used in the report, export them to the environment and
+  ## arrange to close them when the environment goes out of scope.
+  if (length(export) > 0) {
+    list2env(lapply(data$connection, function(x) connections[[x]]),
+             environment)
+    res$connection <- data$connection
+    reg.finalizer(environment, function(e) {
+      orderly_db_disconnect(connections[export])
+    })
   }
 
   orderly_db_build_metadata(res)
@@ -117,7 +146,10 @@ orderly_db_build_metadata <- function(data) {
     data = lapply(data$data, function(d) {
       list(rows = jsonlite::unbox(nrow(d)),
            cols = names(d))
-    }))
+    }),
+    connection = lapply(data$connection, jsonlite::unbox)
+  )
+
   jsonlite::toJSON(dat, auto_unbox = FALSE, pretty = FALSE, na = "null",
                    null = "null")
 }
@@ -127,4 +159,11 @@ orderly_db_connect <- function(name, config) {
   x <- config[[name]]
   driver <- getExportedValue(x$driver[[1L]], x$driver[[2L]])
   do.call(DBI::dbConnect, c(list(driver()), x$args))
+}
+
+
+orderly_db_disconnect <- function(connections) {
+  for (con in connections) {
+    DBI::dbDisconnect(con)
+  }
 }

--- a/tests/testthat/examples/connection/orderly.yml
+++ b/tests/testthat/examples/connection/orderly.yml
@@ -1,0 +1,14 @@
+orderly2.db:
+  data:
+    dat1:
+      query: SELECT * FROM mtcars
+      database: source
+  connection:
+    con1: source
+
+script: script.R
+
+artefacts:
+  staticgraph:
+    description: A graph of things
+    filenames: mygraph.png

--- a/tests/testthat/examples/connection/script.R
+++ b/tests/testthat/examples/connection/script.R
@@ -1,0 +1,7 @@
+dat_cmp <- DBI::dbReadTable(con1, "mtcars")
+
+stopifnot(isTRUE(all.equal(dat1, dat_cmp)))
+
+png("mygraph.png")
+plot(dat1)
+dev.off()

--- a/tests/testthat/examples/connectiononly/orderly.yml
+++ b/tests/testthat/examples/connectiononly/orderly.yml
@@ -1,0 +1,10 @@
+orderly2.db:
+  connection:
+    con1: source
+
+script: script.R
+
+artefacts:
+  staticgraph:
+    description: A graph of things
+    filenames: mygraph.png

--- a/tests/testthat/examples/connectiononly/script.R
+++ b/tests/testthat/examples/connectiononly/script.R
@@ -1,0 +1,5 @@
+dat1 <- DBI::dbReadTable(con1, "mtcars")
+
+png("mygraph.png")
+plot(dat1)
+dev.off()

--- a/tests/testthat/test-plugin.R
+++ b/tests/testthat/test-plugin.R
@@ -135,7 +135,7 @@ test_that("validate db for sqlite", {
 test_that("validate orderly.yml read", {
   mock_root <- list(config = list(orderly2.db = list(db = list())))
   expect_error(
-    orderly_db_read(list(), "orderly.yml", mock_root),
+    orderly_db_read(list(1), "orderly.yml", mock_root),
     "'orderly.yml:orderly2.db' must be named")
   expect_error(
     orderly_db_read(list(data = list(a = TRUE)), "orderly.yml", mock_root),

--- a/tests/testthat/test-plugin.R
+++ b/tests/testthat/test-plugin.R
@@ -193,6 +193,14 @@ test_that("validate read connection", {
 })
 
 
+test_that("require either connection or data", {
+  mock_root <- list(config = list(orderly2.db = list(db = list())))
+  expect_error(
+    orderly_db_read(list(), "orderly.yml", mock_root),
+    "At least one of 'data' or 'connection' must be given")
+})
+
+
 test_that("pull data from run function", {
   cars <- cbind(name = rownames(mtcars), mtcars)
   rownames(cars) <- NULL


### PR DESCRIPTION
Duplicate the syntax and behaviour of the same feature in orderly - allow the user to declare via orderly.yml that they will use a connection in the report and expose it. Don't close it during setup, but arrange to close it on completion