### PR TITLE
vimc-6960: allow temporary views

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly2.db
 Title: Database Support for 'orderly2'
-Version: 0.1.0
+Version: 0.1.1
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Imperial College of Science, Technology and Medicine",

--- a/R/plugin.R
+++ b/R/plugin.R
@@ -89,6 +89,16 @@ orderly_db_run <- function(data, root, parameters, environment, path) {
 
   connections <- list()
 
+  for (nm in names(data$views)) {
+    database <- data$views[[nm]]$database
+    if (is.null(connections[[database]])) {
+      connections[[database]] <- orderly_db_connect(database, config)
+    }
+    sql <- sprintf("CREATE TEMPORARY VIEW %s AS\n%s",
+                   nm, data$views[[nm]]$query)
+    DBI::dbExecute(connections[[database]], sql)
+  }
+
   for (nm in names(data$data)) {
     database <- data$data[[nm]]$database
     if (is.null(connections[[database]])) {

--- a/R/plugin.R
+++ b/R/plugin.R
@@ -178,9 +178,20 @@ validate_query <- function(data, field, databases, prefix) {
 
   for (nm in names(data[[field]])) {
     check_fields(data[[field]][[nm]], sprintf("%s:%s:%s", prefix, field, nm),
-                 c("query", "database"), NULL)
-    match_value(data[[field]][[nm]]$database, databases,
-                sprintf("%s:%s:%s:database", prefix, field, nm))
+                 "query", "database")
+    if (is.null(data[[field]][[nm]]$database)) {
+      if (length(databases) > 1L) {
+        stop(paste(
+          sprintf("More than one database configured (%s); a 'database'",
+                  paste(squote(databases), collapse = ", ")),
+          sprintf("field is required for '%s:%s:%s'", prefix, field, nm)),
+          call. = FALSE)
+      }
+      data[[field]][[nm]]$database <- databases[[1]]
+    } else {
+      match_value(data[[field]][[nm]]$database, databases,
+                  sprintf("%s:%s:%s:database", prefix, field, nm))
+    }
 
     query <- data[[field]][[nm]]$query
     assert_character(query, sprintf("%s:%s:%s:query", prefix, field, nm))

--- a/tests/testthat/examples/view/orderly.yml
+++ b/tests/testthat/examples/view/orderly.yml
@@ -1,0 +1,15 @@
+orderly2.db:
+  views:
+    thedata:
+      query: SELECT mpg, cyl FROM mtcars
+      database: source
+  data:
+    dat:
+      query: SELECT * FROM thedata
+      database: source
+
+script: script.R
+artefacts:
+  staticgraph:
+    description: A graph of things
+    filenames: mygraph.png

--- a/tests/testthat/examples/view/script.R
+++ b/tests/testthat/examples/view/script.R
@@ -1,0 +1,4 @@
+png("mygraph.png")
+par(mar = c(15, 4, .5, .5))
+plot(mpg ~ cyl, dat, las = 2)
+dev.off()

--- a/tests/testthat/test-plugin.R
+++ b/tests/testthat/test-plugin.R
@@ -139,7 +139,7 @@ test_that("validate orderly.yml read", {
     "'orderly.yml:orderly2.db' must be named")
   expect_error(
     orderly_db_read(list(data = list(a = TRUE)), "orderly.yml", mock_root),
-    "Fields missing from orderly.yml:orderly2.db:data:a: query, database")
+    "Fields missing from orderly.yml:orderly2.db:data:a: query")
   expect_error(
     orderly_db_read(
       list(data = list(a = list(query = TRUE, database = "other"))),
@@ -170,6 +170,29 @@ test_that("validate orderly.yml read", {
       list(data = list(a = list(query = tmp, database = "db"))),
       "orderly.yml", mock_root),
     list(data = list(a = list(query = "SELECT\n*", database = "db"))))
+})
+
+
+test_that("fall back on default db if not specified", {
+  mock_root <- list(config = list(orderly2.db = list(db = list())))
+  expect_equal(
+    orderly_db_read(
+      list(data = list(a = list(query = "SELECT *"))),
+      "orderly.yml", mock_root),
+    list(data = list(a = list(query = "SELECT *", database = "db"))))
+})
+
+
+test_that("error if db not specified and more than one db possible", {
+  mock_root <- list(config = list(
+                      orderly2.db = list(db1 = list(), db2 = list())))
+  expect_error(
+    orderly_db_read(
+      list(data = list(a = list(query = "SELECT *"))),
+      "orderly.yml", mock_root),
+    paste("More than one database configured ('db1', 'db2');",
+          "a 'database' field is required for 'orderly.yml:orderly2.db:data:a"),
+    fixed = TRUE)
 })
 
 

--- a/tests/testthat/test-plugin.R
+++ b/tests/testthat/test-plugin.R
@@ -265,3 +265,18 @@ test_that("can construct plugin", {
   expect_identical(orderly_db_plugin(),
                    orderly2:::.plugins$orderly2.db)
 })
+
+
+test_that("can construct a view, then read from it", {
+  root <- test_prepare_example("view", list(mtcars = mtcars))
+  env <- new.env()
+  id <- orderly2::orderly_run("view", root = root, envir = env)
+  expect_type(id, "character")
+  expect_true(file.exists(
+    file.path(root, "archive", "view", id, "mygraph.png")))
+
+  con <- DBI::dbConnect(RSQLite::SQLite(), file.path(root, "source.sqlite"))
+  ## View not present here, it was only available to the client that
+  ## created it.
+  expect_equal(DBI::dbListTables(con), "mtcars")
+})

--- a/tests/testthat/test-plugin.R
+++ b/tests/testthat/test-plugin.R
@@ -275,8 +275,10 @@ test_that("can construct a view, then read from it", {
   expect_true(file.exists(
     file.path(root, "archive", "view", id, "mygraph.png")))
 
-  con <- DBI::dbConnect(RSQLite::SQLite(), file.path(root, "source.sqlite"))
-  ## View not present here, it was only available to the client that
-  ## created it.
-  expect_equal(DBI::dbListTables(con), "mtcars")
+  path_db <- file.path(root, "source.sqlite")
+  withr::with_db_connection(
+    list(con = DBI::dbConnect(RSQLite::SQLite(), path_db)),
+    ## View not present here, it was only available to the client that
+    ## created it.
+    expect_equal(DBI::dbListTables(con), "mtcars"))
 })

--- a/tests/testthat/test-plugin.R
+++ b/tests/testthat/test-plugin.R
@@ -197,7 +197,7 @@ test_that("require either connection or data", {
   mock_root <- list(config = list(orderly2.db = list(db = list())))
   expect_error(
     orderly_db_read(list(), "orderly.yml", mock_root),
-    "At least one of 'data' or 'connection' must be given")
+    "At least one of 'data' or 'views' or 'connection' must be given")
 })
 
 


### PR DESCRIPTION
This PR adds orderly's temporary view support into the plugin. As with orderly, this uses basically the same validation as the data extraction queries. I've also set up the "fall back to single db" functionality, as I'd not set that up previously.

After this we just have instances to sort out I think